### PR TITLE
Update settings.component.html DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/app/settings.component.html
+++ b/frontend/src/app/settings.component.html
@@ -3,7 +3,7 @@
 
 <div *ngIf="errorMessage">
   <div class="alert alert-danger alert-dismissible" #errorMessageAlert>
-    <div [innerHTML]="errorMessage"></div>
+    <div [innerText]="errorMessage"></div>
     <button type="button" class="close" aria-label="Close" (click)="closeErrorMessage()">
       <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.